### PR TITLE
[ADMINAPI-992] Update GitHub Actions in AdminApi-2.x to Use Latest

### DIFF
--- a/.github/workflows/api-e2e-multitenant.yml
+++ b/.github/workflows/api-e2e-multitenant.yml
@@ -31,7 +31,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Copy application folder to docker context
         run: |
@@ -57,9 +57,9 @@ jobs:
           './E2E Tests/gh-action-setup/inspect.sh' adminapi
 
       - name: Setup node
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: "16"
+          node-version: "20"
 
       - name: Install Tools
         run: npm install -g newman newman-reporter-htmlextra postman-combine-collections
@@ -90,14 +90,14 @@ jobs:
 
       - name: Upload Docker logs
         if: failure()
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         with:
           name: docker-logs
           path: Application/EdFi.Ods.AdminApi/docker-logs/
           retention-days: 5
 
       - name: Upload Html results
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         if: success() || failure()
         with:
           name: test-html-results
@@ -105,7 +105,7 @@ jobs:
           retention-days: 5
 
       - name: Upload xml results
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         if: success() || failure()
         with:
           name: test-xml-results
@@ -122,10 +122,10 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Download artifacts
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a #v3.0.2
+        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 #v4.1.1
 
       - name: Send report to Zephyr
         run: |

--- a/.github/workflows/api-e2e-singletenant.yml
+++ b/.github/workflows/api-e2e-singletenant.yml
@@ -31,7 +31,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Copy application folder to docker context
         run: |
@@ -57,7 +57,7 @@ jobs:
           './E2E Tests/gh-action-setup/inspect.sh' adminapi
 
       - name: Setup node
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: "16"
 
@@ -89,14 +89,14 @@ jobs:
 
       - name: Upload Docker logs
         if: failure()
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         with:
           name: docker-logs
           path: Application/EdFi.Ods.AdminApi/docker-logs/
           retention-days: 5
 
       - name: Upload Html results
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         if: success() || failure()
         with:
           name: test-html-results
@@ -104,7 +104,7 @@ jobs:
           retention-days: 5
 
       - name: Upload xml results
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         if: success() || failure()
         with:
           name: test-xml-results
@@ -121,10 +121,10 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Download artifacts
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a #v3.0.2
+        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 #v4.1.1
 
       - name: Send report to Zephyr
         run: |

--- a/.github/workflows/on-pullrequest-dockerfile.yml
+++ b/.github/workflows/on-pullrequest-dockerfile.yml
@@ -40,7 +40,7 @@ jobs:
           ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Copy application folder to docker context
         if: ${{ matrix.dockerfile.type == 'local' }}


### PR DESCRIPTION
GitHub Action Workflows were updated on the following uses:

actions/checkout
actions/upload-artifact
actions/download-artifact