### PR TITLE
[ADMINAPI - 2649] - DRAFT - Update Automapper AdminApiMappingProfile

### DIFF
--- a/Application/EdFi.Ods.AdminApi/Infrastructure/AutoMapper/AdminApiMappingProfile.cs
+++ b/Application/EdFi.Ods.AdminApi/Infrastructure/AutoMapper/AdminApiMappingProfile.cs
@@ -77,6 +77,13 @@ public class AdminApiMappingProfile : Profile
             .ForMember(dst => dst.DefaultAuthorizationStrategiesForCRUD, opt => opt.MapFrom(src => src.DefaultAuthStrategiesForCRUD))
             .ForMember(dst => dst.Children, opt => opt.MapFrom(src => src.Children));
 
+        CreateMap<ResourceClaim, ChildrenClaimSetResource>()
+             .ForMember(dst => dst.Name, opt => opt.MapFrom(src => src.Name))
+             .ForMember(dst => dst.Actions, opt => opt.MapFrom(src => src.Actions))
+             .ForMember(dst => dst.AuthorizationStrategyOverridesForCRUD, opt => opt.MapFrom(src => src.AuthStrategyOverridesForCRUD))
+             .ForMember(dst => dst.DefaultAuthorizationStrategiesForCRUD, opt => opt.MapFrom(src => src.DefaultAuthStrategiesForCRUD))
+             .ForMember(dst => dst.Children, opt => opt.MapFrom(src => src.Children));
+
         CreateMap<ClaimSetResourceClaimModel, ChildrenClaimSetResource>()
             .ForMember(dst => dst.Name, opt => opt.MapFrom(src => src.Name))
             .ForMember(dst => dst.Actions, opt => opt.MapFrom(src => src.Actions))


### PR DESCRIPTION
## Description.

This pull request is not part of a ticket from Jira Tracker. 

This bug was reported in this [ticket ](https://dellfoundation.lightning.force.com/lightning/r/Case/500VL000009FGyaYAG/view) from the salesforce ticket system.

**The Ticket description says:**

With the latest AdminApi 2.2.0 docker image, some calls to /v2/claimSets/{id} fail with a 500 internal server error. For example, the "Ed-Fi Sandbox", "Assessment Vendor", and "District Hosted SIS Vendor" all fail, but the "AB Connect" claimset works fine.

In the AdminApi application logs the following message is logged.

```
{
"message": "An uncaught error has occurred",
"error": {
"Message": "Error mapping types.\n\nMapping types:\nList\u00601 -\u003E List\u00601\nSystem.Collections.Generic.List\u00601[[EdFi.Ods.AdminApi.Infrastructure.ClaimSetEditor.ResourceClaim, EdFi.Ods.AdminApi, Version=2.2.0.0, Culture=neutral, PublicKeyToken=null]] -\u003E System.Collections.Generic.List\u00601[[EdFi.Ods.AdminApi.Features.ClaimSets.ClaimSetResourceClaimModel, EdFi.Ods.AdminApi, Version=2.2.0.0, Culture=neutral, PublicKeyToken=null]]",
"StackTrace": " at lambda_method1594(Closure, Object, List\u00601, ResolutionContext)\n at EdFi.Ods.AdminApi.Features.ClaimSets.ReadClaimSets.GetClaimSet(IGetClaimSetByIdQuery getClaimSetByIdQuery, IGetResourcesByClaimSetIdQuery getResourcesByClaimSetIdQuery, IGetApplicationsByClaimSetIdQuery getApplications, IMapper mapper, Int32 id) in /home/runner/work/AdminAPI-2.x/AdminAPI-2.x/Application/EdFi.Ods.AdminApi/Features/ClaimSets/ReadClaimSets.cs:line 64\n at lambda_method88(Closure, Object, HttpContext)\n at Microsoft.AspNetCore.Routing.EndpointMiddleware.Invoke(HttpContext httpContext)\n at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)\n at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)\n at EdFi.Ods.AdminApi.Infrastructure.MultiTenancy.TenantResolverMiddleware.InvokeAsync(HttpContext context, RequestDelegate next) in /home/runner/work/AdminAPI-2.x/AdminAPI-2.x/Application/EdFi.Ods.AdminApi/Infrastructure/MultiTenancy/TenantIdentificationMiddleware.cs:line 90\n at Microsoft.AspNetCore.Builder.UseMiddlewareExtensions.InterfaceMiddlewareBinder.\u003C\u003Ec__DisplayClass2_0.\u003C\u003CCreateMiddleware\u003Eb__0\u003Ed.MoveNext()\n--- End of stack trace from previous location ---\n at EdFi.Ods.AdminApi.Features.RequestLoggingMiddleware.Invoke(HttpContext context, ILogger\u00601 logger) in /home/runner/work/AdminAPI-2.x/AdminAPI-2.x/Application/EdFi.Ods.AdminApi/Features/RequestLoggingMiddleware.cs:line 36"
},
"traceId": "0HN403GMBNL6U:00000005"
}
```
