### PR TITLE
[ADMINAPI-1190] Refactor database context configuration to use query splitting behavior for SQL Server and PostgreSQL

### DIFF
--- a/Application/EdFi.Ods.AdminApi/AdminConsole/Configurations/DatabaseBuilderExtension.cs
+++ b/Application/EdFi.Ods.AdminApi/AdminConsole/Configurations/DatabaseBuilderExtension.cs
@@ -30,35 +30,53 @@ public static class DatabaseBuilderExtension
             case DbProviders.SqlServer:
                 /// Admin
                 webApplicationBuilder.Services.AddDbContext<IDbContext, AdminConsoleMsSqlContext>(
-                (sp, options) =>
-                {
-                    options.UseSqlServer(AdminConnection(sp).AdminConnectionString);
-                });
+                    (sp, options) =>
+                    {
+                        options.UseSqlServer(
+                            AdminConnection(sp).AdminConnectionString,
+                            o => o.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery)
+                        );
+                    }
+                );
 
                 /// Security
                 webApplicationBuilder.Services.AddDbContext<AdminConsoleSecurityMsSqlContext>(
-                (sp, options) =>
-                {
-                    options.UseSqlServer(AdminConnection(sp).SecurityConnectionString);
-                });
+                    (sp, options) =>
+                    {
+                        options.UseSqlServer(
+                            AdminConnection(sp).SecurityConnectionString,
+                            o => o.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery)
+                        );
+                    }
+                );
                 break;
             case DbProviders.PostgreSql:
                 /// Admin
                 webApplicationBuilder.Services.AddDbContext<IDbContext, AdminConsolePgSqlContext>(
-                (sp, options) =>
-                {
-                    options.UseNpgsql(AdminConnection(sp).AdminConnectionString);
-                });
+                    (sp, options) =>
+                    {
+                        options.UseNpgsql(
+                            AdminConnection(sp).AdminConnectionString,
+                            o => o.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery)
+                        );
+                    }
+                );
 
                 /// Security
                 webApplicationBuilder.Services.AddDbContext<AdminConsoleSecurityPgSqlContext>(
-                (sp, options) =>
-                {
-                    options.UseNpgsql(AdminConnection(sp).SecurityConnectionString);
-                });
+                    (sp, options) =>
+                    {
+                        options.UseNpgsql(
+                            AdminConnection(sp).SecurityConnectionString,
+                            o => o.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery)
+                        );
+                    }
+                );
                 break;
             default:
-                throw new ArgumentException($"Unexpected DB setup error. Engine '{databaseEngine}' was parsed as valid but is not configured for startup.");
+                throw new ArgumentException(
+                    $"Unexpected DB setup error. Engine '{databaseEngine}' was parsed as valid but is not configured for startup."
+                );
         }
 
         TenantConfiguration AdminConnection(IServiceProvider serviceProvider)
@@ -66,15 +84,23 @@ public static class DatabaseBuilderExtension
             var connection = new TenantConfiguration();
             if (multiTenancyEnabled)
             {
-                var tenant = serviceProvider.GetRequiredService<IContextProvider<TenantConfiguration>>().Get();
-                if (tenant != null && !string.IsNullOrEmpty(tenant.AdminConnectionString) && !string.IsNullOrEmpty(tenant.SecurityConnectionString))
+                var tenant = serviceProvider
+                    .GetRequiredService<IContextProvider<TenantConfiguration>>()
+                    .Get();
+                if (
+                    tenant != null
+                    && !string.IsNullOrEmpty(tenant.AdminConnectionString)
+                    && !string.IsNullOrEmpty(tenant.SecurityConnectionString)
+                )
                 {
                     connection.AdminConnectionString = tenant.AdminConnectionString;
                     connection.SecurityConnectionString = tenant.SecurityConnectionString;
                 }
                 else
                 {
-                    throw new ArgumentException($"Admin database connection setup error. Tenant not configured correctly.");
+                    throw new ArgumentException(
+                        $"Admin database connection setup error. Tenant not configured correctly."
+                    );
                 }
             }
             else


### PR DESCRIPTION
# Testing

⚠️ integration tests failed on my computer. I don't know if it was due to this change or something else - I have not yet switched back to the `main` branch to test. Will be interesting to see what happens in Actions.

# Is this safe?

I asked CoPilot if there are any downsides to making this change. Below is its response. This seems like a good compromise: the usage of the application is not so heavy that a few extra database round trips will likely to be a problem.

----

Yes, there are some trade-offs when switching to QuerySplittingBehavior.SplitQuery:

## Pros

* Avoids Cartesian explosion (huge result sets) when including multiple collections.
* Can improve performance and reduce memory usage for complex queries.

## Cons

* Executes multiple SQL queries instead of one, which may increase database round-trips.
* May cause inconsistent results if the underlying data changes between queries (rare, but possible).
* Slightly more complex query logic, which could impact transaction isolation in edge cases.

## Summary

For most scenarios with multiple collection includes, SplitQuery is safer and more efficient. However, if you have strict requirements for atomicity or want to minimize database calls, review your use case before switching.