### PR TITLE
[ADMINAPI-1181] Switch to using official ASP.Net rate limiting

### DIFF
--- a/Application/EdFi.Ods.AdminApi.Common/Settings/AppSettings.cs
+++ b/Application/EdFi.Ods.AdminApi.Common/Settings/AppSettings.cs
@@ -33,3 +33,23 @@ public class SwaggerSettings
     public bool EnableSwagger { get; set; }
     public string? DefaultTenant { get; set; }
 }
+
+
+public class IpRateLimitingOptions
+{
+    public bool EnableEndpointRateLimiting { get; set; }
+    public bool StackBlockedRequests { get; set; }
+    public string RealIpHeader { get; set; } = string.Empty;
+    public string ClientIdHeader { get; set; } = string.Empty;
+    public int HttpStatusCode { get; set; }
+    public List<string>? IpWhitelist { get; set; }
+    public List<string>? EndpointWhitelist { get; set; }
+    public List<GeneralRule>? GeneralRules { get; set; }
+
+    public class GeneralRule
+    {
+        public string Endpoint { get; set; } = string.Empty;
+        public string Period { get; set; } = string.Empty;
+        public int Limit { get; set; }
+    }
+}

--- a/Application/EdFi.Ods.AdminApi.UnitTests/Infrastructure/WebApplicationBuilderExtensionsTests.cs
+++ b/Application/EdFi.Ods.AdminApi.UnitTests/Infrastructure/WebApplicationBuilderExtensionsTests.cs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.RateLimiting;
+using EdFi.Ods.AdminApi.Common.Settings;
+using EdFi.Ods.AdminApi.Infrastructure;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+
+namespace EdFi.Ods.AdminApi.UnitTests.Infrastructure;
+
+[TestFixture]
+public class WebApplicationBuilderExtensionsTests
+{
+    [Test]
+    public void ConfigureRateLimiting_WhenDisabled_ShouldConfigureNoLimiter()
+    {
+        // Arrange
+        var builder = CreateWebApplicationBuilder(false);
+
+        // Act
+        WebApplicationBuilderExtensions.ConfigureRateLimiting(builder);
+
+        // Assert
+        var services = builder.Services.BuildServiceProvider();
+        var options = services.GetRequiredService<IOptions<RateLimiterOptions>>().Value;
+
+        Assert.That(options, Is.Not.Null);
+
+        // Build an app to test the global limiter
+        var app = builder.Build();
+        var httpContext = new DefaultHttpContext();
+        var globalLimiter = app.Services.GetRequiredService<IOptions<RateLimiterOptions>>().Value.GlobalLimiter;
+
+        Assert.That(globalLimiter, Is.Not.Null);
+
+        // The global limiter should be configured as a NoLimiter when disabled
+        var acquireResult = globalLimiter.AttemptAcquire(httpContext);
+        Assert.That(acquireResult.IsAcquired, Is.True);
+    }
+
+    [Test]
+    public void ConfigureRateLimiting_WhenEnabled_ShouldConfigureRejectionStatusCode()
+    {
+        // Arrange
+        var builder = CreateWebApplicationBuilder(true, httpStatusCode: 429);
+
+        // Act
+        WebApplicationBuilderExtensions.ConfigureRateLimiting(builder);
+
+        // Assert
+        var services = builder.Services.BuildServiceProvider();
+        var options = services.GetRequiredService<IOptions<RateLimiterOptions>>().Value;
+
+        Assert.That(options, Is.Not.Null);
+        Assert.That(options.RejectionStatusCode, Is.EqualTo(429));
+    }
+
+    [Test]
+    public void ConfigureRateLimiting_WithEndpointRules_ShouldConfigureEndpointSpecificLimiters()
+    {
+        // Arrange
+        var builder = CreateWebApplicationBuilder(true, new[]
+        {
+            new GeneralRule { Endpoint = "POST:/Connect/Register", Period = "1m", Limit = 3 }
+        });
+
+        // Act
+        WebApplicationBuilderExtensions.ConfigureRateLimiting(builder);
+
+        // Assert
+        var services = builder.Services.BuildServiceProvider();
+        var options = services.GetRequiredService<IOptions<RateLimiterOptions>>().Value;
+
+        Assert.That(options, Is.Not.Null);
+
+        // Build an app to test the endpoint limiters
+        var app = builder.Build();
+        var globalLimiter = app.Services.GetRequiredService<IOptions<RateLimiterOptions>>().Value.GlobalLimiter;
+
+        Assert.That(globalLimiter, Is.Not.Null);
+
+        // Test with a matching endpoint
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Method = "POST";
+        httpContext.Request.Path = "/Connect/Register";
+
+        // First 3 requests should be allowed for the matching endpoint
+        for (int i = 0; i < 3; i++)
+        {
+            var acquireResult = globalLimiter.AttemptAcquire(httpContext);
+            Assert.That(acquireResult.IsAcquired, Is.True, $"Request {i + 1} should be allowed");
+        }
+
+        // 4th request should be rejected
+        var fourthResult = globalLimiter.AttemptAcquire(httpContext);
+        Assert.That(fourthResult.IsAcquired, Is.False, "4th request should be rejected");
+
+        // Test with a non-matching endpoint
+        var differentContext = new DefaultHttpContext();
+        differentContext.Request.Method = "GET";
+        differentContext.Request.Path = "/api/different";
+
+        var differentResult = globalLimiter.AttemptAcquire(differentContext);
+        Assert.That(differentResult.IsAcquired, Is.True, "Non-matching endpoint should be allowed");
+    }
+
+    private static WebApplicationBuilder CreateWebApplicationBuilder(
+        bool enableEndpointRateLimiting,
+        IEnumerable<GeneralRule> generalRules = null,
+        int httpStatusCode = (int)HttpStatusCode.TooManyRequests)
+    {
+        var configValues = new Dictionary<string, string>
+        {
+            { "IpRateLimiting:EnableEndpointRateLimiting", enableEndpointRateLimiting.ToString() },
+            { "IpRateLimiting:HttpStatusCode", httpStatusCode.ToString() }
+        };
+
+        if (generalRules != null)
+        {
+            int index = 0;
+            foreach (var rule in generalRules)
+            {
+                configValues[$"IpRateLimiting:GeneralRules:{index}:Endpoint"] = rule.Endpoint;
+                configValues[$"IpRateLimiting:GeneralRules:{index}:Period"] = rule.Period;
+                configValues[$"IpRateLimiting:GeneralRules:{index}:Limit"] = rule.Limit.ToString();
+                index++;
+            }
+        }
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configValues)
+            .Build();
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Configuration.AddConfiguration(configuration);
+        return builder;
+    }
+
+    private class GeneralRule
+    {
+        public string Endpoint { get; set; } = string.Empty;
+        public string Period { get; set; } = string.Empty;
+        public int Limit { get; set; }
+    }
+}

--- a/Application/EdFi.Ods.AdminApi/EdFi.Ods.AdminApi.csproj
+++ b/Application/EdFi.Ods.AdminApi/EdFi.Ods.AdminApi.csproj
@@ -23,7 +23,6 @@
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.2" />
     <PackageReference Include="Asp.Versioning.Http" Version="8.1.0" />
-    <PackageReference Include="AspNetCoreRateLimit" Version="5.0.0" />
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="7.3.67" />

--- a/Application/EdFi.Ods.AdminApi/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/Application/EdFi.Ods.AdminApi/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -13,6 +13,8 @@ using EdFi.Ods.AdminApi.Common.Infrastructure.Context;
 using EdFi.Ods.AdminApi.Common.Infrastructure.Database;
 using EdFi.Ods.AdminApi.Common.Infrastructure.Extensions;
 using EdFi.Ods.AdminApi.Common.Infrastructure.MultiTenancy;
+using EdFi.Ods.AdminApi.Common.Infrastructure.Providers.Interfaces;
+using EdFi.Ods.AdminApi.Common.Infrastructure.Providers;
 using EdFi.Ods.AdminApi.Common.Infrastructure.Security;
 using EdFi.Ods.AdminApi.Common.Settings;
 using EdFi.Ods.AdminApi.Infrastructure.Api;
@@ -36,6 +38,7 @@ public static class WebApplicationBuilderExtensions
 
     public static void AddServices(this WebApplicationBuilder webApplicationBuilder)
     {
+        webApplicationBuilder.Services.AddSingleton<ISymmetricStringEncryptionProvider, Aes256SymmetricStringEncryptionProvider>();
         ConfigureRateLimiting(webApplicationBuilder);
         ConfigurationManager config = webApplicationBuilder.Configuration;
         webApplicationBuilder.Services.Configure<AppSettings>(config.GetSection("AppSettings"));

--- a/Application/EdFi.Ods.AdminApi/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/Application/EdFi.Ods.AdminApi/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -3,7 +3,9 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Net;
 using System.Reflection;
+using System.Threading.RateLimiting;
 using EdFi.Admin.DataAccess.Contexts;
 using EdFi.Common.Extensions;
 using EdFi.Ods.AdminApi.Common.Infrastructure;
@@ -21,6 +23,7 @@ using EdFi.Security.DataAccess.Contexts;
 using FluentValidation;
 using FluentValidation.AspNetCore;
 using Microsoft.AspNetCore.Http.Json;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Net.Http.Headers;
 using Microsoft.OpenApi.Models;
@@ -33,6 +36,7 @@ public static class WebApplicationBuilderExtensions
 
     public static void AddServices(this WebApplicationBuilder webApplicationBuilder)
     {
+        ConfigureRateLimiting(webApplicationBuilder);
         ConfigurationManager config = webApplicationBuilder.Configuration;
         webApplicationBuilder.Services.Configure<AppSettings>(config.GetSection("AppSettings"));
         EnableMultiTenancySupport(webApplicationBuilder);
@@ -372,6 +376,67 @@ public static class WebApplicationBuilderExtensions
 
             return builder.Options;
         }
+    }
+
+    public static void ConfigureRateLimiting(WebApplicationBuilder builder)
+    {
+        // Bind IpRateLimiting section
+        builder.Services.Configure<IpRateLimitingOptions>(builder.Configuration.GetSection("IpRateLimiting"));
+
+        // Add new rate limiting policy using config
+        builder.Services.AddRateLimiter(options =>
+        {
+            var config = builder.Configuration.GetSection("IpRateLimiting").Get<IpRateLimitingOptions>();
+
+            if (config == null || !config.EnableEndpointRateLimiting)
+            {
+                options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(_ => RateLimitPartition.GetNoLimiter("none"));
+                return;
+            }
+            // Set global options
+            options.RejectionStatusCode = config?.HttpStatusCode ?? (int)HttpStatusCode.TooManyRequests;
+
+            if (config?.GeneralRules != null)
+            {
+                foreach (var rule in config.GeneralRules)
+                {
+                    // Only support fixed window for now, parse period (e.g., "1m")
+                    var window = rule.Period.EndsWith('m') ? TimeSpan.FromMinutes(int.Parse(rule.Period.TrimEnd('m'))) : TimeSpan.FromMinutes(1);
+                    // Register a named limiter for each endpoint
+                    options.AddFixedWindowLimiter(rule.Endpoint, _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = rule.Limit,
+                        Window = window,
+                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                        QueueLimit = 0
+                    });
+                }
+                // Use a global policy selector to apply endpoint-specific limiters
+                options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(context =>
+                {
+                    var path = context.Request.Path.Value;
+                    var method = context.Request.Method;
+                    foreach (var rule in config.GeneralRules)
+                    {
+                        var parts = rule.Endpoint.Split(':');
+                        // Only support fixed window for now, parse period (e.g., "1m")
+                        var window = rule.Period.EndsWith('m') ? TimeSpan.FromMinutes(int.Parse(rule.Period.TrimEnd('m'))) : TimeSpan.FromMinutes(1);
+                        if (path != null && parts.Length == 2 && method.Equals(parts[0], StringComparison.OrdinalIgnoreCase) && path.Equals(parts[1], StringComparison.OrdinalIgnoreCase))
+                        {
+                            return RateLimitPartition.GetFixedWindowLimiter(rule.Endpoint, _ => new FixedWindowRateLimiterOptions
+                            {
+                                PermitLimit = rule.Limit,
+                                Window = window,
+                                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                                QueueLimit = 0
+                            });
+                        }
+                    }
+                    // No limiter for this endpoint
+                    return RateLimitPartition.GetNoLimiter("none");
+                });
+            }
+        });
     }
 
     private enum HttpVerbOrder

--- a/Application/EdFi.Ods.AdminApi/Program.cs
+++ b/Application/EdFi.Ods.AdminApi/Program.cs
@@ -3,27 +3,15 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using AspNetCoreRateLimit;
 using EdFi.Ods.AdminApi.AdminConsole;
 using EdFi.Ods.AdminApi.AdminConsole.Configurations;
 using EdFi.Ods.AdminApi.Common.Infrastructure;
 using EdFi.Ods.AdminApi.Common.Infrastructure.MultiTenancy;
-using EdFi.Ods.AdminApi.Common.Infrastructure.Providers;
-using EdFi.Ods.AdminApi.Common.Infrastructure.Providers.Interfaces;
 using EdFi.Ods.AdminApi.Features;
 using EdFi.Ods.AdminApi.Infrastructure;
 using log4net;
 
 var builder = WebApplication.CreateBuilder(args);
-
-//Rate Limit
-builder.Services.AddMemoryCache();
-builder.Services.Configure<IpRateLimitOptions>(builder.Configuration.GetSection("IpRateLimiting"));
-builder.Services.AddSingleton<IIpPolicyStore, MemoryCacheIpPolicyStore>();
-builder.Services.AddSingleton<IRateLimitCounterStore, MemoryCacheRateLimitCounterStore>();
-builder.Services.AddSingleton<IRateLimitConfiguration, RateLimitConfiguration>();
-builder.Services.AddSingleton<ISymmetricStringEncryptionProvider, Aes256SymmetricStringEncryptionProvider>();
-builder.Services.AddInMemoryRateLimiting();
 
 // logging
 var _logger = LogManager.GetLogger("Program");
@@ -54,11 +42,11 @@ if (!string.IsNullOrEmpty(pathBase))
 
 AdminApiVersions.Initialize(app);
 
-app.UseIpRateLimiting();
 //The ordering here is meaningful: Logging -> Routing -> Auth -> Endpoints
 app.UseMiddleware<RequestLoggingMiddleware>();
 app.UseMiddleware<TenantResolverMiddleware>();
 app.UseRouting();
+app.UseRateLimiter();
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapFeatureEndpoints();
@@ -81,3 +69,5 @@ if (app.Configuration.GetValue<bool>("SwaggerSettings:EnableSwagger"))
 }
 
 app.Run();
+
+

--- a/Application/EdFi.Ods.AdminApi/Program.cs
+++ b/Application/EdFi.Ods.AdminApi/Program.cs
@@ -46,8 +46,8 @@ AdminApiVersions.Initialize(app);
 app.UseMiddleware<RequestLoggingMiddleware>();
 app.UseMiddleware<TenantResolverMiddleware>();
 app.UseRouting();
-app.UseRateLimiter();
 app.UseAuthentication();
+app.UseRateLimiter();
 app.UseAuthorization();
 app.MapFeatureEndpoints();
 


### PR DESCRIPTION
This pull request introduces rate limiting functionality to the application, replacing the existing `AspNetCoreRateLimit` package with a custom implementation using `Microsoft.AspNetCore.RateLimiting`. It includes new configuration options, updates to the application setup, and comprehensive unit tests for the rate limiting feature.

### Rate Limiting Implementation:

* Added the `IpRateLimitingOptions` class in `AppSettings.cs` to define configuration options for rate limiting, including endpoint-specific rules and global settings.
* Implemented the `ConfigureRateLimiting` method in `WebApplicationBuilderExtensions.cs` to set up rate limiting policies based on configuration, including endpoint-specific limiters using fixed windows.
* Replaced the `AspNetCoreRateLimit` package with `Microsoft.AspNetCore.RateLimiting` in `EdFi.Ods.AdminApi.csproj` and removed related code from `Program.cs`. [[1]](diffhunk://#diff-eae821e9cdb4d43d07c322d6809fea9a08801819146bb84d753c3a7b0df0f1b5L26) [[2]](diffhunk://#diff-ed71334ffec8276925a4a009add2cc7a6fb986be4e31408260269ecfe761ecfbL6-L27) [[3]](diffhunk://#diff-ed71334ffec8276925a4a009add2cc7a6fb986be4e31408260269ecfe761ecfbL57-R50)

### Application Setup Updates:

* Updated `AddServices` method in `WebApplicationBuilderExtensions.cs` to register the rate limiting configuration and encryption provider.
* Added `UseRateLimiter` middleware in `Program.cs` to enable rate limiting in the application pipeline.

### Unit Tests:

* Added comprehensive unit tests in `WebApplicationBuilderExtensionsTests.cs` to validate rate limiting behavior, including scenarios for disabled rate limiting, rejection status codes, and endpoint-specific rules.