### PR TITLE
[ADMINAPI-1310] - Fix claimset import to include grandchild ResourceClaims

### DIFF
--- a/Application/EdFi.Ods.AdminApi.DBTests/ClaimSetEditorTests/CopyClaimSetCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApi.DBTests/ClaimSetEditorTests/CopyClaimSetCommandTests.cs
@@ -3,60 +3,60 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Linq;
 using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
 using Moq;
 using NUnit.Framework;
 using Shouldly;
-using System.Linq;
 using ClaimSet = EdFi.Security.DataAccess.Models.ClaimSet;
 
 namespace EdFi.Ods.AdminApi.DBTests.ClaimSetEditorTests;
 
 [TestFixture]
 public class CopyClaimSetCommandTests : SecurityDataTestBase
+{
+    [Test]
+    public void ShouldCopyClaimSet()
     {
-        [Test]
-        public void ShouldCopyClaimSet()
+        var testClaimSet = new ClaimSet { ClaimSetName = "TestClaimSet" };
+        Save(testClaimSet);
+
+        var testResourceClaims = SetupClaimSetResourceClaimActions(testClaimSet,
+           UniqueNameList("ParentRc", 3), UniqueNameList("ChildRc", 1));
+
+        var newClaimSet = new Mock<ICopyClaimSetModel>();
+        newClaimSet.Setup(x => x.Name).Returns("TestClaimSet_Copy");
+        newClaimSet.Setup(x => x.OriginalId).Returns(testClaimSet.ClaimSetId);
+
+        var copyClaimSetId = 0;
+        ClaimSet copiedClaimSet = null;
+        using var securityContext = TestContext;
+        var command = new CopyClaimSetCommand(securityContext);
+        copyClaimSetId = command.Execute(newClaimSet.Object);
+        copiedClaimSet = securityContext.ClaimSets.Single(x => x.ClaimSetId == copyClaimSetId);
+
+        copiedClaimSet.ClaimSetName.ShouldBe(newClaimSet.Object.Name);
+        copiedClaimSet.ForApplicationUseOnly.ShouldBe(false);
+        copiedClaimSet.IsEdfiPreset.ShouldBe(false);
+
+        var results = ResourceClaimsForClaimSet(copiedClaimSet.ClaimSetId).ToList();
+
+        var testParentResourceClaimsForId =
+            testResourceClaims.Where(x => x.ClaimSet.ClaimSetId == testClaimSet.ClaimSetId && x.ResourceClaim.ParentResourceClaim == null).Select(x => x.ResourceClaim).ToArray();
+
+        results.Count.ShouldBe(testParentResourceClaimsForId.Length);
+        results.Select(x => x.Name).ShouldBe(testParentResourceClaimsForId.Select(x => x.ResourceName), true);
+        results.Select(x => x.Id).ShouldBe(testParentResourceClaimsForId.Select(x => x.ResourceClaimId), true);
+        results.All(x => x.Actions.All(x => x.Name.Equals("Create") && x.Enabled)).ShouldBe(true);
+
+        foreach (var testParentResourceClaim in testParentResourceClaimsForId)
         {
-            var testClaimSet = new ClaimSet {ClaimSetName = "TestClaimSet"};
-            Save(testClaimSet);
-
-            var testResourceClaims = SetupParentResourceClaimsWithChildren(testClaimSet,
-               UniqueNameList("ParentRc", 3), UniqueNameList("ChildRc", 1));
-
-            var newClaimSet = new Mock<ICopyClaimSetModel>();
-            newClaimSet.Setup(x => x.Name).Returns("TestClaimSet_Copy");
-            newClaimSet.Setup(x => x.OriginalId).Returns(testClaimSet.ClaimSetId);
-
-            var copyClaimSetId = 0;
-            ClaimSet copiedClaimSet = null;
-            using var securityContext = TestContext;
-            var command = new CopyClaimSetCommand(securityContext);
-            copyClaimSetId = command.Execute(newClaimSet.Object);
-            copiedClaimSet = securityContext.ClaimSets.Single(x => x.ClaimSetId == copyClaimSetId);
-
-            copiedClaimSet.ClaimSetName.ShouldBe(newClaimSet.Object.Name);
-            copiedClaimSet.ForApplicationUseOnly.ShouldBe(false);
-            copiedClaimSet.IsEdfiPreset.ShouldBe(false);
-
-            var results = ResourceClaimsForClaimSet(copiedClaimSet.ClaimSetId).ToList();
-
-            var testParentResourceClaimsForId =
-                testResourceClaims.Where(x => x.ClaimSet.ClaimSetId == testClaimSet.ClaimSetId && x.ResourceClaim.ParentResourceClaim == null).Select(x => x.ResourceClaim).ToArray();
-
-            results.Count.ShouldBe(testParentResourceClaimsForId.Length);
-            results.Select(x => x.Name).ShouldBe(testParentResourceClaimsForId.Select(x => x.ResourceName), true);
-            results.Select(x => x.Id).ShouldBe(testParentResourceClaimsForId.Select(x => x.ResourceClaimId), true);
-            results.All(x => x.Actions.All(x => x.Name.Equals("Create") && x.Enabled)).ShouldBe(true);
-
-            foreach (var testParentResourceClaim in testParentResourceClaimsForId)
-            {
-                var testChildren = securityContext.ResourceClaims.Where(x =>
-                    x.ParentResourceClaimId == testParentResourceClaim.ResourceClaimId).ToList();
-                var parentResult = results.First(x => x.Id == testParentResourceClaim.ResourceClaimId);
-                parentResult.Children.Select(x => x.Name).ShouldBe(testChildren.Select(x => x.ResourceName), true);
-                parentResult.Children.Select(x => x.Id).ShouldBe(testChildren.Select(x => x.ResourceClaimId), true);
-                parentResult.Children.All(x => x.Actions.All(x => x.Name.Equals("Create") && x.Enabled)).ShouldBe(true);
-            }
+            var testChildren = securityContext.ResourceClaims.Where(x =>
+                x.ParentResourceClaimId == testParentResourceClaim.ResourceClaimId).ToList();
+            var parentResult = results.First(x => x.Id == testParentResourceClaim.ResourceClaimId);
+            parentResult.Children.Select(x => x.Name).ShouldBe(testChildren.Select(x => x.ResourceName), true);
+            parentResult.Children.Select(x => x.Id).ShouldBe(testChildren.Select(x => x.ResourceClaimId), true);
+            parentResult.Children.All(x => x.Actions.All(x => x.Name.Equals("Create") && x.Enabled)).ShouldBe(true);
+        }
     }
-    }
+}

--- a/Application/EdFi.Ods.AdminApi.DBTests/ClaimSetEditorTests/DeleteClaimSetCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApi.DBTests/ClaimSetEditorTests/DeleteClaimSetCommandTests.cs
@@ -23,12 +23,12 @@ public class DeleteClaimSetCommandTests : SecurityDataTestBase
         var testClaimSetToDelete = new ClaimSet
         { ClaimSetName = "TestClaimSet_Delete" };
         Save(testClaimSetToDelete);
-        SetupParentResourceClaimsWithChildren(testClaimSetToDelete, UniqueNameList("ParentRc", 3), UniqueNameList("ChildRc", 1));
+        SetupClaimSetResourceClaimActions(testClaimSetToDelete, UniqueNameList("ParentRc", 3), UniqueNameList("ChildRc", 1));
 
         var testClaimSetToPreserve = new ClaimSet
         { ClaimSetName = "TestClaimSet_Preserve" };
         Save(testClaimSetToPreserve);
-        var resourceClaimsForPreservedClaimSet = SetupParentResourceClaimsWithChildren(testClaimSetToPreserve, UniqueNameList("ParentRc", 3),
+        var resourceClaimsForPreservedClaimSet = SetupClaimSetResourceClaimActions(testClaimSetToPreserve, UniqueNameList("ParentRc", 3),
             UniqueNameList("ChildRc", 1));
 
         var deleteModel = new Mock<IDeleteClaimSetModel>();

--- a/Application/EdFi.Ods.AdminApi.DBTests/ClaimSetEditorTests/DeleteResourceClaimOnClaimSetCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApi.DBTests/ClaimSetEditorTests/DeleteResourceClaimOnClaimSetCommandTests.cs
@@ -21,7 +21,7 @@ public class DeleteResourceClaimOnClaimSetCommandTests : SecurityDataTestBase
         Save(testClaimSet);
 
         var parentRcNames = UniqueNameList("ParentRc", 2);
-        var testResources = SetupParentResourceClaimsWithChildren(testClaimSet, parentRcNames, UniqueNameList("ChildRc", 1));
+        var testResources = SetupClaimSetResourceClaimActions(testClaimSet, parentRcNames, UniqueNameList("ChildRc", 1));
 
         using var securityContext = TestContext;
         var command = new DeleteResouceClaimOnClaimSetCommand(securityContext);

--- a/Application/EdFi.Ods.AdminApi.DBTests/ClaimSetEditorTests/OverrideDefaultAuthorizationStrategyCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApi.DBTests/ClaimSetEditorTests/OverrideDefaultAuthorizationStrategyCommandTests.cs
@@ -203,7 +203,7 @@ public class OverrideDefaultAuthorizationStrategyCommandTests : SecurityDataTest
         appAuthorizationStrategies = SetupApplicationAuthorizationStrategies().ToList();
         var parentRcNames = UniqueNameList("ParentRc", 2);
 
-        var testResourceClaims = SetupParentResourceClaimsWithChildren(
+        var testResourceClaims = SetupClaimSetResourceClaimActions(
             testClaimSet, parentRcNames, UniqueNameList("Child", 1));
 
         SetupResourcesWithDefaultAuthorizationStrategies(

--- a/Application/EdFi.Ods.AdminApi.DBTests/ClaimSetEditorTests/UpdateResourcesOnClaimSetCommandTests.cs
+++ b/Application/EdFi.Ods.AdminApi.DBTests/ClaimSetEditorTests/UpdateResourcesOnClaimSetCommandTests.cs
@@ -25,7 +25,7 @@ public class UpdateResourcesOnClaimSetCommandTests : SecurityDataTestBase
 
         var parentRcNames = UniqueNameList("ParentRc", 2);
         var childName = "ChildRc098";
-        var testResources = SetupParentResourceClaimsWithChildren(testClaimSet, parentRcNames,
+        var testResources = SetupClaimSetResourceClaimActions(testClaimSet, parentRcNames,
             new List<string> { childName });
 
         var testParentResource = testResources.Single(x => x.ResourceClaim.ResourceName == parentRcNames.First());

--- a/Application/EdFi.Ods.AdminApi.DBTests/Database/QueryTests/GetResourceClaimsAsFlatListQueryTests.cs
+++ b/Application/EdFi.Ods.AdminApi.DBTests/Database/QueryTests/GetResourceClaimsAsFlatListQueryTests.cs
@@ -3,13 +3,12 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Collections.Generic;
+using System.Linq;
 using EdFi.Ods.AdminApi.Infrastructure.Database.Queries;
 using EdFi.Security.DataAccess.Models;
 using NUnit.Framework;
 using Shouldly;
-using System.Collections.Generic;
-using System.Linq;
-using ResourceClaim = EdFi.Security.DataAccess.Models.ResourceClaim;
 
 namespace EdFi.Ods.AdminApi.DBTests.Database.QueryTests;
 
@@ -19,7 +18,17 @@ public class GetResourceClaimsAsFlatListQueryTests : SecurityDataTestBase
     [Test]
     public void ShouldGetResourceClaimsAsFlatList()
     {
-        var testResourceClaims = SetupResourceClaims();
+        var parentPrefix = "ParentRc";
+        var childPrefix = "ChildRc";
+        var grandChildPrefix = "GrandChildRc";
+        var parentResourceNames = UniqueNameList(parentPrefix, 3);
+        var childrenResourceNames = UniqueNameList(childPrefix, 2);
+        var grandChildResourceNames = UniqueNameList(grandChildPrefix, 2);
+
+        var testResourceClaims = SetupResourceClaimsWithChildren(
+                parentResourceNames,
+                childrenResourceNames,
+                grandChildResourceNames);
 
         Infrastructure.ClaimSetEditor.ResourceClaim[] results = null;
         using var securityContext = TestContext;
@@ -29,10 +38,16 @@ public class GetResourceClaimsAsFlatListQueryTests : SecurityDataTestBase
         results.Select(x => x.Name).ShouldBe(testResourceClaims.Select(x => x.ResourceName), true);
         results.Select(x => x.Id).ShouldBe(testResourceClaims.Select(x => x.ResourceClaimId), true);
         results.All(x => x.Actions == null).ShouldBe(true);
-        results.All(x => x.ParentId.Equals(0)).ShouldBe(true);
-        results.All(x => x.ParentName == null).ShouldBe(true);
-        results.All(x => x.Children.Count == 0).ShouldBe(true);
+        //Assert parent Resource Claims
+        results.Count(x => x.ParentId.Equals(0)).ShouldBe(parentResourceNames.Count);
+        results.Count(x => x.Name.StartsWith(parentPrefix)).ShouldBe(parentResourceNames.Count);
+        //Assert child Resource Claims
+        results.Count(x => x.Name.StartsWith(childPrefix)).ShouldBe(parentResourceNames.Count * childrenResourceNames.Count);
+        //Assert grandchild Resource Claims
+        results.Count(x => x.Name.StartsWith(grandChildPrefix)).ShouldBe(parentResourceNames.Count * childrenResourceNames.Count * grandChildResourceNames.Count);
+
     }
+
 
     [Test]
     public void ShouldGetAlphabeticallySortedFlatListForResourceClaims()
@@ -40,7 +55,7 @@ public class GetResourceClaimsAsFlatListQueryTests : SecurityDataTestBase
         var testClaimSet = new ClaimSet
         { ClaimSetName = "TestClaimSet_test" };
         Save(testClaimSet);
-        var testResourceClaims = SetupParentResourceClaimsWithChildren(testClaimSet, UniqueNameList("ParentRc", 3), UniqueNameList("ChildRc", 1)).ToList();
+        var testResourceClaims = SetupClaimSetResourceClaimActions(testClaimSet, UniqueNameList("ParentRc", 3), UniqueNameList("ChildRc", 1)).ToList();
         var parentResourceNames = testResourceClaims.Where(x => x.ResourceClaim?.ParentResourceClaim == null)
             .OrderBy(x => x.ResourceClaim.ResourceName).Select(x => x.ResourceClaim?.ResourceName).ToList();
         var childResourceNames = testResourceClaims.Where(x => x.ResourceClaim?.ParentResourceClaim != null)
@@ -55,22 +70,22 @@ public class GetResourceClaimsAsFlatListQueryTests : SecurityDataTestBase
         results.Where(x => x.ParentId != 0).Select(x => x.Name).ToList().ShouldBe(childResourceNames);
     }
 
-    private IReadOnlyCollection<ResourceClaim> SetupResourceClaims(int resourceClaimCount = 5)
-    {
-        var resourceClaims = new List<ResourceClaim>();
-        foreach (var index in Enumerable.Range(1, resourceClaimCount))
-        {
-            var resourceClaim = new ResourceClaim
-            {
-                ClaimName = $"TestResourceClaim{index:N}",
-                ResourceName = $"TestResourceClaim{index:N}",
-            };
-            resourceClaims.Add(resourceClaim);
-        }
+    //private IReadOnlyCollection<ResourceClaim> SetupResourceClaims(int resourceClaimCount = 5)
+    //{
+    //    var resourceClaims = new List<ResourceClaim>();
+    //    foreach (var index in Enumerable.Range(1, resourceClaimCount))
+    //    {
+    //        var resourceClaim = new ResourceClaim
+    //        {
+    //            ClaimName = $"TestResourceClaim{index:N}",
+    //            ResourceName = $"TestResourceClaim{index:N}",
+    //        };
+    //        resourceClaims.Add(resourceClaim);
+    //    }
 
-        Save(resourceClaims.Cast<object>().ToArray());
+    //    Save(resourceClaims.Cast<object>().ToArray());
 
-        return resourceClaims;
-    }
+    //    return resourceClaims;
+    //}
 
 }

--- a/Application/EdFi.Ods.AdminApi.DBTests/Database/QueryTests/GetResourceClaimsQueryTests.cs
+++ b/Application/EdFi.Ods.AdminApi.DBTests/Database/QueryTests/GetResourceClaimsQueryTests.cs
@@ -6,7 +6,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using EdFi.Ods.AdminApi.Common.Infrastructure;
-using EdFi.Ods.AdminApi.Infrastructure;
 using EdFi.Ods.AdminApi.Infrastructure.Database.Queries;
 using NUnit.Framework;
 using Shouldly;
@@ -125,6 +124,10 @@ public class GetResourceClaimsQueryTests : SecurityDataTestBase
         results.Length.ShouldBe(1);
         results.First().Name.ShouldBe(testResourceClaimsResult.First().ResourceName);
     }
+
+
+
+
 
     private IReadOnlyCollection<ResourceClaim> SetupResourceClaims(int resourceClaimCount = 5)
     {

--- a/Application/EdFi.Ods.AdminApi/Infrastructure/Services/ClaimSetEditor/AddOrEditResourcesOnClaimSetCommand.cs
+++ b/Application/EdFi.Ods.AdminApi/Infrastructure/Services/ClaimSetEditor/AddOrEditResourcesOnClaimSetCommand.cs
@@ -71,13 +71,26 @@ public class AddOrEditResourcesOnClaimSetCommand
     {
         var allResources = new List<ResourceClaim>();
         var parentResources = _getResourceClaimsQuery.Execute().ToList();
-        allResources.AddRange(parentResources);
-        foreach (var children in parentResources.Select(x => x.Children))
+
+        foreach (var resource in parentResources)
         {
-            allResources.AddRange(children);
+            AddResourceWithChildren(resource, allResources);
         }
 
         return allResources;
+    }
+
+    private void AddResourceWithChildren(ResourceClaim resource, List<ResourceClaim> allResources)
+    {
+        allResources.Add(resource);
+
+        if (resource.Children != null && resource.Children.Any())
+        {
+            foreach (var child in resource.Children)
+            {
+                AddResourceWithChildren(child, allResources);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Steps to Reproduce

Import a claimset that contains a ResourceClaim that is a grandchild of a parent ResourceClaim. For example, the claimset “Education Preparation Program” contains the ResourceClaim “candidatePreparation”, which is a grandchild of TPDM.

After the claimset is created, compare the number of records in the table [ClaimSetResourceClaimActions]. The newly imported claimset will be missing the records for the ResourceClaim “candidatePreparation”.

Expected Behavior

Importing claimsets should create all corresponding records in [ClaimSetResourceClaimActions].

Actual Behavior

Missing records in [ClaimSetResourceClaimActions] for the ResourceClaims that are grandchildren of a ResourceClaim